### PR TITLE
Fixed Bower Install Error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "angular-mocks": "~1.3",
     "bootstrap": "~3.1",
     "angular-route": "1.2.16",
-    "auth0-styleguide": "~0.1",
+    "auth0-styleguide": "~2.0.9",
     "auth0-angular" : "~1.1",
     "auth0-widget.js": "~4.0.0"
   },


### PR DESCRIPTION
I received the below error when running "bower install", I was able to correct the problem by updating the "auth0-styleguide" package.

``` shell
bower not-cached    git://github.com/auth0/styleguide.git#~0.1
bower resolve       git://github.com/auth0/styleguide.git#~0.1
bower cached        git://github.com/angular/bower-angular.git#1.2.16
bower validate      1.2.16 against git://github.com/angular/bower-angular.git#1.2.16
bower cached        git://github.com/angular/bower-angular-mocks.git#1.3.17
bower validate      1.3.17 against git://github.com/angular/bower-angular-mocks.git#~1.3
bower cached        git://github.com/lodash/lodash.git#2.4.2
bower validate      2.4.2 against git://github.com/lodash/lodash.git#~2.4
bower cached        git://github.com/twbs/bootstrap.git#3.1.1
bower validate      3.1.1 against git://github.com/twbs/bootstrap.git#~3.1
bower cached        git://github.com/angular/bower-angular-route.git#1.2.16
bower validate      1.2.16 against git://github.com/angular/bower-angular-route.git#1.2.16
bower cached        git://github.com/auth0/auth0-angular.git#1.1.5
bower validate      1.1.5 against git://github.com/auth0/auth0-angular.git#~1.1
bower cached        git://github.com/auth0/widget.git#4.0.48
bower validate      4.0.48 against git://github.com/auth0/widget.git#~4.0.0
bower ENORESTARGET  No tag found that was able to satisfy ~0.1

Additional error details:
Available versions: 2.0.9, 2.0.8, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0.3, 2.0.2, 2.0.1, 2.0.0
```
